### PR TITLE
Use nom 7.0.0-alpha1 to avoid issues with dependencies.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "abnf-core"
 description = "A nom-based parser for ABNF core rules."
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Damian Poddebniak <poddebniak@fh-muenster.de>"]
 readme = "README.md"
 license = "MIT OR Apache-2.0"
@@ -11,4 +11,4 @@ repository = "https://github.com/duesee/abnf-core"
 keywords = ["abnf", "core", "rules", "parser", "nom"]
 
 [dependencies]
-nom = "6"
+nom = "7.0.0-alpha1"


### PR DESCRIPTION
Hey! We use this crate and abnf crate in Leo language: https://github.com/AleoHQ/leo

---

Recently, there has been inconsistency across community due to updates in `nom`, `bitvec` and `funty`. 
Bumping to 0.7.0-alpha1 solves the problem and makes it work. I do understand that it's an alpha version and might not be considered safe, but that's the only solution for now.

Also adds Cargo.lock to the git to maintain best practices.