### PR TITLE
Use nom trait to make input generic (refactored)

### DIFF
--- a/src/complete.rs
+++ b/src/complete.rs
@@ -58,7 +58,9 @@ where
     satisfy(is_cr)(input)
 }
 
-/// CRLF = CR LF ; Internet standard newline
+/// Internet standard newline
+///
+/// CRLF = CR LF
 ///
 /// Note: this variant will strictly expect "\r\n".
 /// Use [crlf_relaxed](fn.crlf_relaxed.html) to accept "\r\n" as well as only "\n".
@@ -147,17 +149,13 @@ where
     satisfy(is_lf)(input)
 }
 
+/// Use of this linear-white-space rule permits lines containing only white
+/// space that are no longer legal in mail headers and have caused
+/// interoperability problems in other contexts.
+///
+/// Do not use when defining mail headers and use with caution in other contexts.
+///
 /// LWSP = *(WSP / CRLF WSP)
-///         ; Use of this linear-white-space rule
-///         ;  permits lines containing only white
-///         ;  space that are no longer legal in
-///         ;  mail headers and have caused
-///         ;  interoperability problems in other
-///         ;  contexts.
-///         ; Do not use when defining mail
-///         ;  headers and use with caution in
-///         ;  other contexts.
-// code as equivalent avoid branching LWSP = *([CRLF] WSP)
 pub fn lwsp<I, E>(input: I) -> IResult<I, I, E>
 where
     I: Clone
@@ -170,6 +168,7 @@ where
     <I as InputIter>::Item: AsChar,
     E: ParseError<I>,
 {
+    // code as equivalent avoid branching LWSP = *([CRLF] WSP)
     recognize(many0_count(terminated(opt(crlf), wsp)))(input)
 }
 

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -1,80 +1,152 @@
+//! ABNF Core Rules (RFC5234 B.1.)
+
+use std::ops::{RangeFrom, RangeTo};
+
 use nom::{
-    branch::alt,
-    bytes::complete::{tag, take},
-    character::complete::{self as character, anychar, line_ending},
-    combinator::{opt, recognize, verify},
-    error::ParseError,
+    bytes::complete::tag,
+    character::complete::satisfy,
+    combinator::{opt, recognize},
+    error::{ErrorKind, ParseError},
     multi::many0_count,
-    sequence::terminated,
-    IResult,
+    sequence::{pair, terminated},
+    AsChar, Err as OutCome, IResult, InputIter, InputLength, Offset, Slice,
 };
 
 use crate::*;
 
 /// ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
-pub fn alpha<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    verify(anychar, |&c| is_alpha(c))(input)
+pub fn alpha<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_alpha)(input)
 }
 
 /// BIT = "0" / "1"
-pub fn bit<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    verify(anychar, |&c| is_bit(c))(input)
+pub fn bit<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_bit)(input)
 }
 
 /// CHAR = %x01-7F ; any 7-bit US-ASCII character, excluding NUL
-pub fn char<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    verify(anychar, |&c| is_char(c))(input)
+pub fn char<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_char)(input)
 }
 
-/// CR = %x0D ; carriage return
-pub fn cr<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    character::char('\r')(input)
+/// Carriage return
+///
+/// CR = %x0D
+pub fn cr<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_cr)(input)
 }
 
 pub fn crlf_strict<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &str, E> {
     tag("\r\n")(input)
 }
 
-pub fn crlf_relaxed<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &str, E> {
-    line_ending(input)
-}
-
 /// CRLF = CR LF ; Internet standard newline
 ///
 /// Note: this variant will strictly expect "\r\n".
 /// Use [crlf_relaxed](fn.crlf_relaxed.html) to accept "\r\n" as well as only "\n".
-pub fn crlf<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &str, E> {
-    crlf_strict(input)
+pub fn crlf<I, E>(input: I) -> IResult<I, (char, char), E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    pair(satisfy(is_cr), satisfy(is_lf))(input)
+}
+
+/// Newline, with and without "\r".
+pub fn crlf_relaxed<I, E>(input: I) -> IResult<I, (Option<char>, char), E>
+where
+    I: InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    pair(opt(satisfy(is_cr)), satisfy(is_lf))(input)
 }
 
 /// CTL = %x00-1F / %x7F ; controls
-pub fn ctl<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    verify(anychar, |&c| is_ctl(c))(input)
+pub fn ctl<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_ctl)(input)
 }
 
 /// DIGIT = %x30-39 ; 0-9
-pub fn digit<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    verify(anychar, |&c| is_digit(c))(input)
+pub fn digit<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_digit)(input)
 }
 
-/// DQUOTE = %x22 ; " (Double Quote)
-pub fn dquote<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    character::char('"')(input)
+/// Double Quote
+///
+/// DQUOTE = %x22
+pub fn dquote<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_dquote)(input)
 }
 
 /// HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
-pub fn hexdig<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    verify(anychar, |&c| is_hexdig(c))(input)
+pub fn hexdig<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_hexdig)(input)
 }
 
-/// HTAB = %x09 ; horizontal tab
-pub fn htab<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    character::char('\t')(input)
+/// Horizontal tab
+///
+/// HTAB = %x09
+pub fn htab<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_htab)(input)
 }
 
-/// LF = %x0A ; linefeed
-pub fn lf<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    character::char('\n')(input)
+/// Linefeed
+///
+/// LF = %x0A
+pub fn lf<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_lf)(input)
 }
 
 /// LWSP = *(WSP / CRLF WSP)
@@ -88,28 +160,63 @@ pub fn lf<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, 
 ///         ;  headers and use with caution in
 ///         ;  other contexts.
 // code as equivalent avoid branching LWSP = *([CRLF] WSP)
-pub fn lwsp<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &str, E> {
+pub fn lwsp<I, E>(input: I) -> IResult<I, I, E>
+where
+    I: Clone
+        + Offset
+        + PartialEq
+        + InputIter
+        + Slice<RangeTo<usize>>
+        + Slice<RangeFrom<usize>>
+        + InputLength,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
     recognize(many0_count(terminated(opt(crlf), wsp)))(input)
 }
 
 /// OCTET = %x00-FF ; 8 bits of data
-pub fn octet(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    take(1usize)(input)
+pub fn octet<E>(input: &[u8]) -> IResult<&[u8], u8, E>
+where
+    for<'a> E: ParseError<&'a [u8]>,
+{
+    match input.split_first() {
+        None => Err(OutCome::Error(E::from_error_kind(
+            input,
+            ErrorKind::Complete,
+        ))),
+        Some((&b, tail)) => Ok((tail, b)),
+    }
 }
 
 /// SP = %x20
-pub fn sp<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    character::char(' ')(input)
+pub fn sp<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_sp)(input)
 }
 
 /// VCHAR = %x21-7E ; visible (printing) characters
-pub fn vchar<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    verify(anychar, |&c| is_vchar(c))(input)
+pub fn vchar<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_char)(input)
 }
 
 /// WSP = SP / HTAB ; white space
-pub fn wsp<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, char, E> {
-    alt((sp, htab))(input)
+pub fn wsp<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputIter + Slice<RangeFrom<usize>>,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_wsp)(input)
 }
 
 #[cfg(test)]
@@ -120,119 +227,128 @@ mod tests {
 
     #[test]
     fn test_alpha() {
-        assert!(alpha::<VerboseError<&str>>("").is_err());
+        assert!(alpha::<_, VerboseError<&str>>("").is_err());
 
-        assert!(alpha::<VerboseError<&str>>("`").is_err());
-        assert_eq!(alpha::<VerboseError<&str>>("a"), Ok(("", 'a')));
-        assert_eq!(alpha::<VerboseError<&str>>("z"), Ok(("", 'z')));
-        assert!(alpha::<VerboseError<&str>>("{").is_err());
+        assert!(alpha::<_, VerboseError<&str>>("`").is_err());
+        assert_eq!(alpha::<_, VerboseError<&str>>("a"), Ok(("", 'a')));
+        assert_eq!(alpha::<_, VerboseError<&str>>("z"), Ok(("", 'z')));
+        assert!(alpha::<_, VerboseError<&str>>("{").is_err());
 
-        assert!(alpha::<VerboseError<&str>>("@").is_err());
-        assert_eq!(alpha::<VerboseError<&str>>("A"), Ok(("", 'A')));
-        assert_eq!(alpha::<VerboseError<&str>>("Z"), Ok(("", 'Z')));
-        assert!(alpha::<VerboseError<&str>>("[").is_err());
+        assert!(alpha::<_, VerboseError<&str>>("@").is_err());
+        assert_eq!(alpha::<_, VerboseError<&str>>("A"), Ok(("", 'A')));
+        assert_eq!(alpha::<_, VerboseError<&str>>("Z"), Ok(("", 'Z')));
+        assert!(alpha::<_, VerboseError<&str>>("[").is_err());
     }
 
     #[test]
     fn test_bit() {
-        assert!(bit::<VerboseError<&str>>("").is_err());
+        assert!(bit::<_, VerboseError<&str>>("").is_err());
 
-        assert!(bit::<VerboseError<&str>>("/").is_err());
-        assert_eq!(bit::<VerboseError<&str>>("0"), Ok(("", '0')));
-        assert_eq!(bit::<VerboseError<&str>>("1"), Ok(("", '1')));
-        assert!(bit::<VerboseError<&str>>("2").is_err());
+        assert!(bit::<_, VerboseError<&str>>("/").is_err());
+        assert_eq!(bit::<_, VerboseError<&str>>("0"), Ok(("", '0')));
+        assert_eq!(bit::<_, VerboseError<&str>>("1"), Ok(("", '1')));
+        assert!(bit::<_, VerboseError<&str>>("2").is_err());
     }
 
     #[test]
     fn test_char() {
-        assert!(char::<VerboseError<&str>>("").is_err());
+        assert!(char::<_, VerboseError<&str>>("").is_err());
 
-        assert!(char::<VerboseError<&str>>("\x00").is_err());
-        assert_eq!(char::<VerboseError<&str>>("\x01"), Ok(("", '\x01')));
-        assert_eq!(char::<VerboseError<&str>>("\x7f"), Ok(("", '\x7f')));
-        assert!(char::<VerboseError<&str>>("\u{80}").is_err());
+        assert!(char::<_, VerboseError<&str>>("\x00").is_err());
+        assert_eq!(char::<_, VerboseError<&str>>("\x01"), Ok(("", '\x01')));
+        assert_eq!(char::<_, VerboseError<&str>>("\x7f"), Ok(("", '\x7f')));
+        assert!(char::<_, VerboseError<&str>>("\u{80}").is_err());
     }
 
     #[test]
     fn test_cr() {
-        assert!(cr::<VerboseError<&str>>("").is_err());
+        assert!(cr::<_, VerboseError<&str>>("").is_err());
 
-        assert!(cr::<VerboseError<&str>>("\x0c").is_err());
-        assert_eq!(cr::<VerboseError<&str>>("\r"), Ok(("", '\r')));
-        assert!(cr::<VerboseError<&str>>("\x0e").is_err());
+        assert!(cr::<_, VerboseError<&str>>("\x0c").is_err());
+        assert_eq!(cr::<_, VerboseError<&str>>("\r"), Ok(("", '\r')));
+        assert!(cr::<_, VerboseError<&str>>("\x0e").is_err());
     }
 
     #[test]
-    fn test_crlf_strict() {
-        assert!(crlf_strict::<VerboseError<&str>>("").is_err());
+    fn test_crlf() {
+        assert!(crlf::<_, VerboseError<&str>>("").is_err());
 
-        assert!(crlf_strict::<VerboseError<&str>>("\x0c").is_err());
-        assert!(crlf_strict::<VerboseError<&str>>("\r").is_err());
-        assert!(crlf_strict::<VerboseError<&str>>("\x0e").is_err());
+        assert!(crlf::<_, VerboseError<&str>>("\x0c").is_err());
+        assert!(crlf::<_, VerboseError<&str>>("\r").is_err());
+        assert!(crlf::<_, VerboseError<&str>>("\x0e").is_err());
 
-        assert!(crlf_strict::<VerboseError<&str>>("\x09").is_err());
-        assert!(crlf_strict::<VerboseError<&str>>("\n").is_err());
-        assert!(crlf_strict::<VerboseError<&str>>("\x0b").is_err());
+        assert!(crlf::<_, VerboseError<&str>>("\x09").is_err());
+        assert!(crlf::<_, VerboseError<&str>>("\n").is_err());
+        assert!(crlf::<_, VerboseError<&str>>("\x0b").is_err());
 
-        assert_eq!(crlf_strict::<VerboseError<&str>>("\r\n"), Ok(("", "\r\n")));
+        assert_eq!(
+            crlf::<_, VerboseError<&str>>("\r\n"),
+            Ok(("", ('\r', '\n')))
+        );
     }
 
     #[test]
     fn test_crlf_relaxed() {
-        assert!(crlf_relaxed::<VerboseError<&str>>("").is_err());
+        assert!(crlf_relaxed::<_, VerboseError<&str>>("").is_err());
 
-        assert!(crlf_relaxed::<VerboseError<&str>>("\x0c").is_err());
-        assert!(crlf_relaxed::<VerboseError<&str>>("\r").is_err());
-        assert!(crlf_relaxed::<VerboseError<&str>>("\x0e").is_err());
+        assert!(crlf_relaxed::<_, VerboseError<&str>>("\x0c").is_err());
+        assert!(crlf_relaxed::<_, VerboseError<&str>>("\r").is_err());
+        assert!(crlf_relaxed::<_, VerboseError<&str>>("\x0e").is_err());
 
-        assert!(crlf_relaxed::<VerboseError<&str>>("\x09").is_err());
-        assert_eq!(crlf_relaxed::<VerboseError<&str>>("\n"), Ok(("", "\n")));
-        assert!(crlf_relaxed::<VerboseError<&str>>("\x0b").is_err());
+        assert!(crlf_relaxed::<_, VerboseError<&str>>("\x09").is_err());
+        assert_eq!(
+            crlf_relaxed::<_, VerboseError<&str>>("\n"),
+            Ok(("", (None, '\n')))
+        );
+        assert!(crlf_relaxed::<_, VerboseError<&str>>("\x0b").is_err());
 
-        assert_eq!(crlf_relaxed::<VerboseError<&str>>("\r\n"), Ok(("", "\r\n")));
+        assert_eq!(
+            crlf_relaxed::<_, VerboseError<&str>>("\r\n"),
+            Ok(("", ((Some('\r'), '\n'))))
+        );
     }
 
     #[test]
     fn test_ctl() {
-        assert!(ctl::<VerboseError<&str>>("").is_err());
+        assert!(ctl::<_, VerboseError<&str>>("").is_err());
 
-        assert!(ctl::<VerboseError<&str>>("\x00").is_ok());
-        assert!(ctl::<VerboseError<&str>>("\x1f").is_ok());
-        assert!(ctl::<VerboseError<&str>>("\x20").is_err());
-        assert!(ctl::<VerboseError<&str>>("\x7f").is_ok());
-        assert!(ctl::<VerboseError<&str>>("\u{80}").is_err());
+        assert!(ctl::<_, VerboseError<&str>>("\x00").is_ok());
+        assert!(ctl::<_, VerboseError<&str>>("\x1f").is_ok());
+        assert!(ctl::<_, VerboseError<&str>>("\x20").is_err());
+        assert!(ctl::<_, VerboseError<&str>>("\x7f").is_ok());
+        assert!(ctl::<_, VerboseError<&str>>("\u{80}").is_err());
     }
 
     #[test]
     fn test_digit() {
-        assert!(digit::<VerboseError<&str>>("").is_err());
+        assert!(digit::<_, VerboseError<&str>>("").is_err());
 
-        assert!(digit::<VerboseError<&str>>("/").is_err());
-        assert_eq!(digit::<VerboseError<&str>>("0"), Ok(("", '0')));
-        assert_eq!(digit::<VerboseError<&str>>("9"), Ok(("", '9')));
-        assert!(digit::<VerboseError<&str>>(":").is_err());
+        assert!(digit::<_, VerboseError<&str>>("/").is_err());
+        assert_eq!(digit::<_, VerboseError<&str>>("0"), Ok(("", '0')));
+        assert_eq!(digit::<_, VerboseError<&str>>("9"), Ok(("", '9')));
+        assert!(digit::<_, VerboseError<&str>>(":").is_err());
     }
 
     // DQUOTE
 
     #[test]
     fn test_hexdig() {
-        assert!(hexdig::<VerboseError<&str>>("").is_err());
+        assert!(hexdig::<_, VerboseError<&str>>("").is_err());
 
-        assert!(hexdig::<VerboseError<&str>>("/").is_err());
-        assert_eq!(hexdig::<VerboseError<&str>>("0"), Ok(("", '0')));
-        assert_eq!(hexdig::<VerboseError<&str>>("9"), Ok(("", '9')));
-        assert!(hexdig::<VerboseError<&str>>(":").is_err());
+        assert!(hexdig::<_, VerboseError<&str>>("/").is_err());
+        assert_eq!(hexdig::<_, VerboseError<&str>>("0"), Ok(("", '0')));
+        assert_eq!(hexdig::<_, VerboseError<&str>>("9"), Ok(("", '9')));
+        assert!(hexdig::<_, VerboseError<&str>>(":").is_err());
 
-        assert!(hexdig::<VerboseError<&str>>("`").is_err());
-        assert_eq!(hexdig::<VerboseError<&str>>("a"), Ok(("", 'a')));
-        assert_eq!(hexdig::<VerboseError<&str>>("f"), Ok(("", 'f')));
-        assert!(hexdig::<VerboseError<&str>>("g").is_err());
+        assert!(hexdig::<_, VerboseError<&str>>("`").is_err());
+        assert_eq!(hexdig::<_, VerboseError<&str>>("a"), Ok(("", 'a')));
+        assert_eq!(hexdig::<_, VerboseError<&str>>("f"), Ok(("", 'f')));
+        assert!(hexdig::<_, VerboseError<&str>>("g").is_err());
 
-        assert!(hexdig::<VerboseError<&str>>("@").is_err());
-        assert_eq!(hexdig::<VerboseError<&str>>("A"), Ok(("", 'A')));
-        assert_eq!(hexdig::<VerboseError<&str>>("F"), Ok(("", 'F')));
-        assert!(hexdig::<VerboseError<&str>>("G").is_err());
+        assert!(hexdig::<_, VerboseError<&str>>("@").is_err());
+        assert_eq!(hexdig::<_, VerboseError<&str>>("A"), Ok(("", 'A')));
+        assert_eq!(hexdig::<_, VerboseError<&str>>("F"), Ok(("", 'F')));
+        assert!(hexdig::<_, VerboseError<&str>>("G").is_err());
     }
 
     // HTAB

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -11,7 +11,10 @@ use nom::{
     AsChar, Err as OutCome, IResult, InputIter, InputLength, Offset, Slice,
 };
 
-use crate::*;
+use crate::{
+    is_alpha, is_bit, is_char, is_cr, is_ctl, is_digit, is_dquote, is_hexdig, is_htab, is_lf,
+    is_sp, is_wsp,
+};
 
 /// ALPHA = %x41-5A / %x61-7A ; A-Z / a-z
 pub fn alpha<I, E>(input: I) -> IResult<I, char, E>

--- a/src/complete.rs
+++ b/src/complete.rs
@@ -3,7 +3,6 @@
 use std::ops::{RangeFrom, RangeTo};
 
 use nom::{
-    bytes::complete::tag,
     character::complete::satisfy,
     combinator::{opt, recognize},
     error::{ErrorKind, ParseError},
@@ -54,10 +53,6 @@ where
     E: ParseError<I>,
 {
     satisfy(is_cr)(input)
-}
-
-pub fn crlf_strict<'a, E: ParseError<&'a str>>(input: &'a str) -> IResult<&'a str, &str, E> {
-    tag("\r\n")(input)
 }
 
 /// CRLF = CR LF ; Internet standard newline

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //!
 //! Parsing of ABNF Core Rules
 //!
-//! See https://tools.ietf.org/html/rfc5234#appendix-B.1
+//! See <https://tools.ietf.org/html/rfc5234#appendix-B.1>
 //!
 
 pub mod complete;
@@ -53,7 +53,7 @@ pub fn is_digit(c: impl AsChar) -> bool {
     matches!(c.as_char(), '\x30'..='\x39')
 }
 
-/// " (Double Quote)
+/// Double Quote (")
 ///
 /// DQUOTE = %x22
 pub fn is_dquote(c: impl AsChar) -> bool {
@@ -61,6 +61,9 @@ pub fn is_dquote(c: impl AsChar) -> bool {
 }
 
 /// HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+///
+/// Note: ABNF strings are case-insensitive so `a` / ... / `f` are allowed, too.
+/// Issue: <https://github.com/duesee/abnf-core/issues/12>
 pub fn is_hexdig(c: impl AsChar) -> bool {
     matches!(c.as_char(), '0'..='9' | 'a'..='f' | 'A'..='F')
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub fn is_cr(c: impl AsChar) -> bool {
 }
 
 // CRLF
+// Not implemented as predicate.
 
 /// Controls
 ///
@@ -66,15 +67,36 @@ pub fn is_hexdig(c: impl AsChar) -> bool {
     matches!(c.as_char(), '0'..='9' | 'a'..='f' | 'A'..='F')
 }
 
-// HTAB
+/// Horizontal tab
+///
+/// HTAB = %x09
+pub fn is_htab(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x09')
+}
 
-// LF
+/// Linefeed
+///
+/// LF = %x0A
+pub fn is_lf(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x0A')
+}
 
 // LWSP
+// Not implemented as predicate.
 
-// OCTET
+/// 8 bits of data
+///
+/// OCTET = %x00-FF
+pub fn is_octet(_: u8) -> bool {
+    true
+}
 
-// SP
+/// Space
+///
+/// SP = %x20
+pub fn is_sp(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x20')
+}
 
 /// Visible (printing) characters
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -112,3 +112,144 @@ pub fn is_vchar(c: impl AsChar) -> bool {
 pub fn is_wsp(c: impl AsChar) -> bool {
     matches!(c.as_char(), '\x20' | '\x09')
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_alpha() {
+        assert!(is_alpha(b'a'));
+        assert!(is_alpha('A'));
+        assert!(is_alpha('z'));
+        assert!(is_alpha('Z'));
+        assert!(!is_alpha('0'));
+        assert!(!is_alpha('9'));
+        assert!(!is_alpha('#'));
+    }
+
+    #[test]
+    fn test_is_bit() {
+        assert!(is_bit(b'0'));
+        assert!(is_bit('1'));
+        assert!(!is_bit('2'));
+        assert!(!is_bit('a'));
+        assert!(!is_bit('A'));
+        assert!(!is_bit('z'));
+        assert!(!is_bit('Z'));
+        assert!(!is_bit('#'));
+    }
+
+    #[test]
+    fn test_is_char() {
+        assert!(is_char(b'a'));
+        assert!(is_char('A'));
+        assert!(is_char('z'));
+        assert!(is_char('Z'));
+        assert!(is_char('\x7F'));
+        assert!(!is_char('\x00'));
+    }
+
+    #[test]
+    fn test_is_cr() {
+        assert!(is_cr(b'\r'));
+        assert!(!is_cr('\n'));
+        assert!(!is_cr('a'));
+        assert!(!is_cr('A'));
+        assert!(!is_cr('z'));
+        assert!(!is_cr('Z'));
+    }
+
+    #[test]
+    fn test_is_ctl() {
+        assert!(is_ctl(b'\x00'));
+        assert!(is_ctl('\x1F'));
+        assert!(is_ctl('\x7F'));
+        assert!(!is_ctl('a'));
+        assert!(!is_ctl('A'));
+        assert!(!is_ctl('z'));
+        assert!(!is_ctl('Z'));
+    }
+
+    #[test]
+    fn test_is_digit() {
+        assert!(is_digit(b'0'));
+        assert!(is_digit('9'));
+        assert!(!is_digit('a'));
+        assert!(!is_digit('A'));
+        assert!(!is_digit('z'));
+        assert!(!is_digit('Z'));
+    }
+
+    #[test]
+    fn test_is_dquote() {
+        assert!(is_dquote(b'"'));
+        assert!(!is_dquote('\''));
+        assert!(!is_dquote('a'));
+        assert!(!is_dquote('A'));
+        assert!(!is_dquote('z'));
+        assert!(!is_dquote('Z'));
+    }
+
+    #[test]
+    fn test_is_hexdig() {
+        assert!(is_hexdig(b'0'));
+        assert!(is_hexdig('9'));
+        assert!(is_hexdig('a'));
+        assert!(is_hexdig('f'));
+        assert!(is_hexdig('A'));
+        assert!(is_hexdig('F'));
+        assert!(!is_hexdig('z'));
+        assert!(!is_hexdig('Z'));
+    }
+
+    #[test]
+    fn test_is_htab() {
+        assert!(is_htab(b'\t'));
+    }
+
+    #[test]
+    fn test_is_lf() {
+        assert!(is_lf(b'\n'));
+        assert!(!is_lf('\r'));
+        assert!(!is_lf('a'));
+        assert!(!is_lf('A'));
+        assert!(!is_lf('z'));
+        assert!(!is_lf('Z'));
+    }
+
+    #[test]
+    fn test_is_octet() {
+        assert!(is_octet(0x00));
+        assert!(is_octet(0x7F));
+        assert!(is_octet(0xFF));
+    }
+
+    #[test]
+    fn test_is_sp() {
+        assert!(is_sp(b' '));
+        assert!(!is_sp('\t'));
+        assert!(!is_sp('a'));
+        assert!(!is_sp('A'));
+        assert!(!is_sp('z'));
+        assert!(!is_sp('Z'));
+    }
+
+    #[test]
+    fn test_is_vchar() {
+        assert!(is_vchar(b'!'));
+        assert!(is_vchar('~'));
+        assert!(!is_vchar('\x20'));
+        assert!(!is_vchar('\x7F'));
+    }
+
+    #[test]
+    fn test_is_wsp() {
+        assert!(is_wsp(b' '));
+        assert!(is_wsp('\t'));
+        assert!(!is_wsp('a'));
+        assert!(!is_wsp('A'));
+        assert!(!is_wsp('z'));
+        assert!(!is_wsp('Z'));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,38 +9,61 @@
 pub mod complete;
 pub mod streaming;
 
-pub fn is_alpha(c: char) -> bool {
-    c.is_ascii_alphabetic()
+use nom::AsChar;
+
+/// A-Z / a-z
+///
+/// ALPHA = %x41-5A / %x61-7A
+pub fn is_alpha(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x41'..='\x5A' | '\x61'..='\x7A')
 }
 
-pub fn is_bit(c: char) -> bool {
-    c == '0' || c == '1'
+/// BIT = "0" / "1"
+/// BIT = %x30 / %x31
+pub fn is_bit(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x30'..='\x31')
 }
 
-pub fn is_char(c: char) -> bool {
-    matches!(c, '\x01'..='\x7F')
+/// Any 7-bit US-ASCII character, excluding NUL
+///
+/// CHAR = %x01-7F
+pub fn is_char(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x01'..='\x7F')
 }
 
-pub fn is_cr(c: char) -> bool {
-    c == '\r'
+/// Carriage return
+///
+/// CR = %x0D
+pub fn is_cr(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x0D')
 }
 
 // CRLF
 
-pub fn is_ctl(c: char) -> bool {
-    matches!(c, '\x00'..='\x1F' | '\x7F')
+/// Controls
+///
+/// CTL = %x00-1F / %x7F
+pub fn is_ctl(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x00'..='\x1F' | '\x7F')
 }
 
-pub fn is_digit(c: char) -> bool {
-    c.is_ascii_digit()
+/// 0-9
+///
+/// DIGIT = %x30-39
+pub fn is_digit(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x30'..='\x39')
 }
 
-pub fn is_dquote(c: char) -> bool {
-    c == '"'
+/// " (Double Quote)
+///
+/// DQUOTE = %x22
+pub fn is_dquote(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x22')
 }
 
-pub fn is_hexdig(c: char) -> bool {
-    c.is_ascii_hexdigit()
+/// HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
+pub fn is_hexdig(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '0'..='9' | 'a'..='f' | 'A'..='F')
 }
 
 // HTAB
@@ -53,14 +76,16 @@ pub fn is_hexdig(c: char) -> bool {
 
 // SP
 
-// VCHAR
-
-// WSP
-
-pub fn is_vchar(c: char) -> bool {
-    matches!(c, '\x21'..='\x7E')
+/// Visible (printing) characters
+///
+/// VCHAR = %x21-7E
+pub fn is_vchar(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x21'..='\x7E')
 }
 
-pub fn is_wsp(c: char) -> bool {
-    matches!(c, '\x20' | '\x09')
+/// White space
+///
+/// WSP = SP / HTAB
+pub fn is_wsp(c: impl AsChar) -> bool {
+    matches!(c.as_char(), '\x20' | '\x09')
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(non_snake_case)]
-
 //!
 //! Parsing of ABNF Core Rules
 //!

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,33 +1,6 @@
 //! ABNF Core Rules (RFC5234 B.1.)
 
-use nom::{
-    branch::alt,
-    bytes::streaming::tag,
-    character::{
-        is_alphabetic, is_digit as nom_is_digit, is_hex_digit as nom_is_hex_digit,
-        streaming::line_ending,
-    },
-    IResult,
-};
-
-/// A-Z / a-z
-///
-/// ALPHA = %x41-5A / %x61-7A
-pub fn is_alpha(byte: u8) -> bool {
-    is_alphabetic(byte)
-}
-
-/// BIT = "0" / "1"
-pub fn is_bit(byte: u8) -> bool {
-    byte == b'0' || byte == b'1'
-}
-
-/// Any 7-bit US-ASCII character, excluding NUL
-///
-/// CHAR = %x01-7F
-pub fn is_char(byte: u8) -> bool {
-    matches!(byte, 0x01..=0x7f)
-}
+use nom::{branch::alt, bytes::streaming::tag, character::streaming::line_ending, IResult};
 
 /// Carriage return
 ///
@@ -48,30 +21,11 @@ pub fn crlf_relaxed(input: &[u8]) -> IResult<&[u8], &[u8]> {
     line_ending(input)
 }
 
-/// Controls
-///
-/// CTL = %x00-1F / %x7F
-pub fn is_ctl(byte: u8) -> bool {
-    matches!(byte, 0x00..=0x1f | 0x7f)
-}
-
-/// 0-9
-///
-/// DIGIT = %x30-39
-pub fn is_digit(byte: u8) -> bool {
-    nom_is_digit(byte)
-}
-
 /// Double Quote
 ///
 /// DQUOTE = %x22
 pub fn dquote(input: &[u8]) -> IResult<&[u8], &[u8]> {
     tag("\"")(input)
-}
-
-/// HEXDIG = DIGIT / "A" / "B" / "C" / "D" / "E" / "F"
-pub fn is_hexdig(byte: u8) -> bool {
-    nom_is_hex_digit(byte)
 }
 
 /// Horizontal tab
@@ -103,13 +57,6 @@ pub fn lf(input: &[u8]) -> IResult<&[u8], &[u8]> {
 /// SP = %x20
 pub fn sp(input: &[u8]) -> IResult<&[u8], &[u8]> {
     tag(" ")(input)
-}
-
-/// Visible (printing) characters
-///
-/// VCHAR = %x21-7E
-pub fn is_vchar(byte: u8) -> bool {
-    matches!(byte, 0x21..=0x7E)
 }
 
 /// White space

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -214,3 +214,19 @@ where
 {
     satisfy(is_wsp)(input)
 }
+
+#[cfg(test)]
+mod tests {
+    use nom::error::VerboseError;
+
+    use super::*;
+
+    #[test]
+    fn test_cr() {
+        assert!(cr::<_, VerboseError<_>>("\n").is_err());
+        assert_eq!(cr::<_, VerboseError<_>>("\r"), Ok(("", '\r')));
+
+        assert!(cr::<_, VerboseError<_>>(&b"\n"[..]).is_err());
+        assert_eq!(cr::<_, VerboseError<_>>(&b"\r"[..]), Ok((&b""[..], '\r')));
+    }
+}

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,45 +1,82 @@
 //! ABNF Core Rules (RFC5234 B.1.)
 
-use nom::{branch::alt, bytes::streaming::tag, character::streaming::line_ending, IResult};
+use std::ops::RangeFrom;
+
+use nom::{
+    character::streaming::satisfy, combinator::opt, error::ParseError, sequence::pair, AsChar,
+    IResult, InputIter, InputLength, Slice,
+};
+
+use crate::{is_char, is_cr, is_dquote, is_htab, is_lf, is_sp, is_wsp};
 
 /// Carriage return
 ///
 /// CR = %x0D
-pub fn cr(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    tag("\r")(input)
+pub fn cr<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_cr)(input)
 }
 
 /// Internet standard newline
 ///
 /// CRLF = CR LF
-pub fn crlf(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    tag("\r\n")(input)
+pub fn crlf<I, E>(input: I) -> IResult<I, (char, char), E>
+where
+    I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    pair(satisfy(is_cr), satisfy(is_lf))(input)
 }
 
 /// Newline, with and without "\r".
-pub fn crlf_relaxed(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    line_ending(input)
+pub fn crlf_relaxed<I, E>(input: I) -> IResult<I, (Option<char>, char), E>
+where
+    I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    pair(opt(satisfy(is_cr)), satisfy(is_lf))(input)
 }
 
 /// Double Quote
 ///
 /// DQUOTE = %x22
-pub fn dquote(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    tag("\"")(input)
+pub fn dquote<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_dquote)(input)
 }
 
 /// Horizontal tab
 ///
 /// HTAB = %x09
-pub fn htab(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    tag("\x09")(input)
+pub fn htab<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_htab)(input)
 }
 
 /// Linefeed
 ///
 /// LF = %x0A
-pub fn lf(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    tag("\n")(input)
+pub fn lf<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_lf)(input)
 }
 
 /// Use of this linear-white-space rule permits lines containing only white
@@ -55,13 +92,33 @@ pub fn lf(input: &[u8]) -> IResult<&[u8], &[u8]> {
 /// OCTET = %x00-FF
 
 /// SP = %x20
-pub fn sp(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    tag(" ")(input)
+pub fn sp<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_sp)(input)
+}
+
+/// VCHAR = %x21-7E ; visible (printing) characters
+pub fn vchar<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_char)(input)
 }
 
 /// White space
 ///
 /// WSP = SP / HTAB
-pub fn wsp(input: &[u8]) -> IResult<&[u8], &[u8]> {
-    alt((sp, htab))(input)
+pub fn wsp<I, E>(input: I) -> IResult<I, char, E>
+where
+    I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,
+    <I as InputIter>::Item: AsChar,
+    E: ParseError<I>,
+{
+    satisfy(is_wsp)(input)
 }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -24,6 +24,9 @@ where
 /// Internet standard newline
 ///
 /// CRLF = CR LF
+///
+/// Note: this variant will strictly expect "\r\n".
+/// Use [crlf_relaxed](fn.crlf_relaxed.html) to accept "\r\n" as well as only "\n".
 pub fn crlf<I, E>(input: I) -> IResult<I, (char, char), E>
 where
     I: InputLength + InputIter + Slice<RangeFrom<usize>> + Clone,


### PR DESCRIPTION
@Stargateur I tried to improve the commit history a bit. I think it is okay now. What do you think? This branch is almost equal to yours, except that I moved the tests and improved the documentation here and there. Also I changed the `is_octet` function to accept a `u8` input and rectified the test `test_is_octet`.